### PR TITLE
Link insert in Redactor fix

### DIFF
--- a/src/DataForm/Field/Redactor.php
+++ b/src/DataForm/Field/Redactor.php
@@ -46,7 +46,7 @@ class Redactor extends Field
 		      "});" .
 		      "return false;" .
 		      "}");
-        Rapyd::script("tinymce.init({selector: '#".$this->name."', file_browser_callback : elFinderBrowser, plugins: 'image', convert_urls: false});");
+        Rapyd::script("tinymce.init({selector: '#".$this->name."', file_browser_callback : elFinderBrowser, plugins: 'image, link', convert_urls: false});");
         break;
 
       case "hidden":


### PR DESCRIPTION
Without this,  TinyMCE Insert Link button doesn't appear in redactor, because plugin is not loaded.