### PR TITLE
getOtherKey relation was removed from BelongsToMany (5.3 to 5.4), use Pivot instead...

### DIFF
--- a/src/DataForm/Field/Field.php
+++ b/src/DataForm/Field/Field.php
@@ -137,7 +137,7 @@ abstract class Field extends Widget
                 $this->db_name = $name;
             }
 
-            if (is_a(@$this->relation, 'Illuminate\Database\Eloquent\Relations\BelongsToMany')){
+            if (is_a(@$this->relation, 'Illuminate\Database\Eloquent\Relations\Pivot')){
 
                 $this->rel_other_key = $this->relation->getOtherKey();
 


### PR DESCRIPTION
Illuminate\Database\Eloquent\Relations\Pivot

This affected an issue when adding anything (admin, role,  link, etc) inside the panel application:

BadMethodCallException: Call to undefined method Illuminate\Database\Query\Builder::getOtherKey()