### PR TITLE
Ensure sure $this->values and $this->local_options gets set for tags

### DIFF
--- a/src/DataForm/Field/Tags.php
+++ b/src/DataForm/Field/Tags.php
@@ -16,7 +16,7 @@ class Tags extends Field
     public $remote;
     public $separator = "&nbsp;";
     public $serialization_sep = ",";
-    public $local_options;
+    public $local_options = [];
 
     public $record_id;
     public $record_label;

--- a/src/DataForm/Field/Tags.php
+++ b/src/DataForm/Field/Tags.php
@@ -55,6 +55,13 @@ class Tags extends Field
         }
         parent::getValue();
 
+        if (is_array($this->value)) {
+            $this->values = $this->value;
+        }
+        else {
+            $this->values = explode($this->serialization_sep, $this->value);
+        }
+
         if (count($this->local_options)) {
             $description_arr = array();
             $this->fill_tags = "";


### PR DESCRIPTION
At the moment, the tags array (like Checkboxgroup, Daterange, etc.) is filled from `$this->values`, but the Tags class does not seem to set this from `$this->value`, as the other widgets do.

This uses the logic from Checkboxgroup to fill `$this->values` from `$this->value` before updating the tags widget. 

It also covers the case where no options are supplied, as `$this->local_options` is uninitialized, and so `count($this->local_options)` in `src/DataForm/Field/Tags.php:65` fails. I can split this out as a separate PR, but as it's part of the same initialization flow, and both are small changes, it seemed sensible to pair them.